### PR TITLE
Fix `hash_hmac` arguments order

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -102,7 +102,7 @@ class Request {
    */
   protected function signature(Token $token)
   {
-    return hash_hmac('sha256', $token->getSecret(), $this->stringToSign());
+    return hash_hmac('sha256', $this->stringToSign(), $token->getSecret());
   }
 
   /**


### PR DESCRIPTION
From PHP document [hash_hmac](http://sg2.php.net/manual/en/function.hash-hmac.php)

```
string hash_hmac ( string $algo , string $data , string $key [, bool $raw_output = false ] )
```

But in Request.php

```
return hash_hmac('sha256', $token->getSecret(), $this->stringToSign());
```

`hash_hmac` expects `data` first then `key`
