### PR TITLE
Sort parameters array

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -137,6 +137,9 @@ class Request {
 
     // Remove the signature key
     unset($array['auth_signature']);
+    
+    // Sort array
+    ksort($array);
 
     // Encode array to http string
     return http_build_query($array);


### PR DESCRIPTION
In other languages, the Dict/HashTable is un-ordered, better to sort the elements by keys.
