### PR TITLE
http_build_query() without url encoding

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -142,7 +142,7 @@ class Request {
     ksort($array);
 
     // Encode array to http string
-    return http_build_query($array);
+    return urldecode(http_build_query($array));
   }
 
   /**


### PR DESCRIPTION
According to [mloughran/signature](https://github.com/mloughran/signature) and [siuying/IGSignature](https://github.com/siuying/IGSignature)

The `parameterString` shouldn't be URL encoded
1. https://github.com/mloughran/signature/blob/master/lib/signature/query_encoder.rb#L16
2. https://github.com/siuying/IGSignature/blob/master/IGSignature/Signature/IGQueryEncoder.m#L13
