### PR TITLE
Fixed problem, during slow connection timestamps did not match as guest ...

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -66,7 +66,8 @@ class Auth
         $body = $this->getBodyParams();
 
         $request   = new Request($this->method, $this->uri, $body);
-        $signature = $request->sign($token);
+        $auth_timestamp = isset( $this->params['auth_timestamp'] ) ? $this->params['auth_timestamp'] : null;
+        $signature = $request->sign($token, $auth_timestamp);
 
         foreach ($this->guards as $guard) {
             $guard->check($auth, $signature);

--- a/src/Request.php
+++ b/src/Request.php
@@ -42,14 +42,15 @@ class Request
      * Sign the Request with a Token
      *
      * @param Token $token
+     * @param integer $auth_timestamp
      * @return array
      */
-    public function sign(Token $token)
+    public function sign(Token $token, $auth_timestamp = null)
     {
         $auth = [
             'auth_version'   => $this->version,
             'auth_key'       => $token->key(),
-            'auth_timestamp' => Carbon::now()->timestamp
+            'auth_timestamp' => isset($auth_timestamp) ? $auth_timestamp : Carbon::now()->timestamp
         ];
 
         $payload = $this->payload($auth, $this->params);


### PR DESCRIPTION
...timestamp was compared against host timestamps when host timestamp was generated locally and used in signature generation while it should only be generated and used to compare timedifference between guest and local timestamps as allowed difference is set in in Guard/CheckTimestamp $grace.