### PR TITLE
Validate requests against future expired timestamps

### DIFF
--- a/src/Guards/CheckTimestamp.php
+++ b/src/Guards/CheckTimestamp.php
@@ -35,7 +35,7 @@ class CheckTimestamp implements Guard
             throw new SignatureTimestampException('The timestamp has not been set');
         }
 
-        if (($auth['auth_timestamp'] - Carbon::now()->timestamp) >= $this->grace) {
+        if (abs($auth['auth_timestamp'] - Carbon::now()->timestamp) >= $this->grace) {
             throw new SignatureTimestampException('The timestamp is invalid');
         }
 

--- a/tests/Guards/CheckTimestampTest.php
+++ b/tests/Guards/CheckTimestampTest.php
@@ -34,6 +34,16 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function should_throw_exception_on_future_expired_timestamp()
+    {
+        $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureTimestampException');
+
+        $timestamp = Carbon::now()->subHour()->timestamp;
+
+        $this->guard->check(['auth_timestamp' => $timestamp], []);
+    }
+
+    /** @test */
     public function should_return_true_with_valid_timestamp()
     {
         $timestamp = Carbon::now()->timestamp;


### PR DESCRIPTION
Currently `CheckTimestamp` only checks if the current time is before the signed-request timestamp.

`($auth['auth_timestamp'] - Carbon::now()->timestamp) >= $this->grace` will only ever be true when the request timestamp is somehow *grater* than the current timestamp.

I've added an `abs()` around the calculation ([just like in the Ruby library](https://github.com/mloughran/signature/blob/master/lib/signature.rb#L204)), so that the grace period is applied in the past and the future.

Not sure if this should be considered a bugfix or an BC break in the eyes of semver. If it's a BC break, I'd opt for adding a `CheckTimestamp($grace = 600, $checkFuture = false)` flag to maintain BC, or perhaps a new `CheckFutureTimestamp` guard?