### PR TITLE
Create signature using auth fields

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -60,7 +60,7 @@ class Auth
         $auth = $this->getAuthParams();
         $body = $this->getBodyParams();
 
-        $request   = new Request($this->method, $this->uri, $body);
+        $request   = new Request($this->method, $this->uri, $body, $auth['auth_timestamp']);
         $signature = $request->sign($token);
 
         foreach ($this->guards as $guard) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -52,7 +52,7 @@ class Request
             'auth_timestamp' => Carbon::now()->timestamp
         ];
 
-        $payload = $this->payload($this->params);
+        $payload = $this->payload($auth, $this->params);
 
         $signature = $this->signature($payload, $this->method, $this->uri, $token->secret());
 
@@ -67,13 +67,14 @@ class Request
      * @param array $params
      * @return array
      */
-    public function payload(array $params)
+    public function payload(array $auth, array $params)
     {
-        array_change_key_case($params, CASE_LOWER);
+        $payload = array_merge($auth, $params);
+        array_change_key_case($payload, CASE_LOWER);
 
-        ksort($params);
+        ksort($payload);
 
-        return $params;
+        return $payload;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -25,17 +25,24 @@ class Request
     private $params;
 
     /**
+     * @var integer
+     */
+    private $timestamp;
+
+    /**
      * Create a new Request
      *
      * @param string $method
      * @param string $uri
      * @param array $params
+     * @param integer $timestamp
      */
-    public function __construct($method, $uri, array $params)
+    public function __construct($method, $uri, array $params, $timestamp = null)
     {
-        $this->method = strtoupper($method);
-        $this->uri    = $uri;
-        $this->params = $params;
+        $this->method    = strtoupper($method);
+        $this->uri       = $uri;
+        $this->params    = $params;
+        $this->timestamp = $timestamp ?: Carbon::now()->timestamp;
     }
 
     /**
@@ -49,7 +56,7 @@ class Request
         $auth = [
             'auth_version'   => $this->version,
             'auth_key'       => $token->key(),
-            'auth_timestamp' => Carbon::now()->timestamp
+            'auth_timestamp' => $this->timestamp,
         ];
 
         $payload = $this->payload($auth, $this->params);
@@ -64,6 +71,7 @@ class Request
     /**
      * Create the payload
      *
+     * @param array $auth
      * @param array $params
      * @return array
      */

--- a/src/Request.php
+++ b/src/Request.php
@@ -7,7 +7,7 @@ class Request
     /**
      * @var string
      */
-    private $version = '3.0.2';
+    private $version = '3.0.4';
 
     /**
      * @var string

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -18,7 +18,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
             'auth_version'   => '3.0.2',
             'auth_key'       => 'abc123',
             'auth_timestamp' => '1412506800',
-            'auth_signature' => '48e36e5dbe7f187f17b11eb632f6334be13c43a65f25c9281a42a61265884765',
+            'auth_signature' => '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5',
             'name' => 'Philip Brown'
         ];
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -12,8 +12,6 @@ class AuthTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
-
         $this->params = [
             'auth_version'   => '3.0.2',
             'auth_key'       => 'abc123',
@@ -58,6 +56,8 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureTimestampException');
 
+        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
+
         $this->params['auth_timestamp'] = Carbon::now()->addHour()->timestamp;
 
         $auth = new Auth('POST', 'users', $this->params, [
@@ -71,6 +71,8 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     public function should_throw_exception_on_invalid_signature()
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureSignatureException');
+
+        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
 
         $this->params['auth_signature'] = '';
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -13,10 +13,10 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->params = [
-            'auth_version'   => '3.0.2',
+            'auth_version'   => '3.0.4',
             'auth_key'       => 'abc123',
             'auth_timestamp' => '1412506800',
-            'auth_signature' => '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5',
+            'auth_signature' => '58df9a58bc27f8722481c8b97233855cc5bb0c42e2c141e6858c0130edbfa8bd',
             'name' => 'Philip Brown'
         ];
 

--- a/tests/Guards/CheckVersionTest.php
+++ b/tests/Guards/CheckVersionTest.php
@@ -17,7 +17,7 @@ class CheckVersionTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureVersionException');
 
-        $this->guard->check([], ['auth_version' => '3.0.2']);
+        $this->guard->check([], ['auth_version' => '3.0.4']);
     }
 
     /** @test */
@@ -25,12 +25,12 @@ class CheckVersionTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureVersionException');
 
-        $this->guard->check(['auth_version' => '1.1'], ['auth_version' => '3.0.2']);
+        $this->guard->check(['auth_version' => '1.1'], ['auth_version' => '3.0.4']);
     }
 
     /** @test */
     public function should_return_true_with_valid_version_number()
     {
-        $this->assertTrue($this->guard->check(['auth_version' => '3.0.2'], ['auth_version' => '3.0.2']));
+        $this->assertTrue($this->guard->check(['auth_version' => '3.0.4'], ['auth_version' => '3.0.4']));
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -23,7 +23,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
 
         $this->auth = [
-            'auth_version'   => '3.0.2',
+            'auth_version'   => '3.0.4',
             'auth_key'       => 'abc123',
             'auth_timestamp' => Carbon::now()->timestamp
         ];
@@ -40,7 +40,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'auth_key'       => 'abc123',
             'auth_timestamp' => '1412506800',
-            'auth_version'   => '3.0.2',
+            'auth_version'   => '3.0.4',
             'name'           => 'Philip Brown'
         ], $payload);
     }
@@ -53,7 +53,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $signature = $this->request->signature($payload, 'POST', 'users', 'qwerty');
 
         $this->assertEquals(
-            '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5', $signature);
+            '58df9a58bc27f8722481c8b97233855cc5bb0c42e2c141e6858c0130edbfa8bd', $signature);
     }
 
     /** @test */
@@ -61,11 +61,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $auth = $this->request->sign($this->token);
 
-        $this->assertEquals('3.0.2', $auth['auth_version']);
+        $this->assertEquals('3.0.4', $auth['auth_version']);
         $this->assertEquals('abc123', $auth['auth_key']);
         $this->assertEquals('1412506800', $auth['auth_timestamp']);
         $this->assertEquals(
-            '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5', $auth['auth_signature']);
+            '58df9a58bc27f8722481c8b97233855cc5bb0c42e2c141e6858c0130edbfa8bd', $auth['auth_signature']);
     }
 }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -35,20 +35,25 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function should_create_payload()
     {
-        $payload = $this->request->payload($this->params);
+        $payload = $this->request->payload($this->auth, $this->params);
 
-        $this->assertEquals('Philip Brown', $payload['name']);
+        $this->assertEquals([
+            'auth_key'       => 'abc123',
+            'auth_timestamp' => '1412506800',
+            'auth_version'   => '3.0.2',
+            'name'           => 'Philip Brown'
+        ], $payload);
     }
 
     /** @test */
     public function should_create_signature()
     {
-        $payload = $this->request->payload($this->params);
+        $payload = $this->request->payload($this->auth, $this->params);
 
         $signature = $this->request->signature($payload, 'POST', 'users', 'qwerty');
 
         $this->assertEquals(
-            '48e36e5dbe7f187f17b11eb632f6334be13c43a65f25c9281a42a61265884765', $signature);
+            '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5', $signature);
     }
 
     /** @test */
@@ -60,7 +65,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('abc123', $auth['auth_key']);
         $this->assertEquals('1412506800', $auth['auth_timestamp']);
         $this->assertEquals(
-            '48e36e5dbe7f187f17b11eb632f6334be13c43a65f25c9281a42a61265884765', $auth['auth_signature']);
+            '3743d35b97f6ee0859d63e78f13fa493225a5edcac8fb0536c6fcfba7ff540f5', $auth['auth_signature']);
     }
 }
 


### PR DESCRIPTION
#6 reported an issue with timestamps in signature verification, though the fix (a656f4efa99dca7143093dca227ad685891548c4) was incorrect. (Sorry for the incoming wall of text, I hope it's clear enough!)

This PR does three things:

1. Fix a vulnerability by injecting the auth_ fields back into the payload.
2. Fix the original issue (#6) by using the passed `auth_timestamp` field when creating the new signature for comparison.
3. Bump the signature version, as the method of creating signatures has changed once more.

# 1. The vulnerability

When creating signatures, the auth_ fields should be present in the signature payload so as those values can be relied upon for verification.

As it stands, a possible attack is as follows:

1. Send signed request
1. Attacker intercepts request
1. Attacker re-sends request, but outside of the CheckTimestamp grace period - receiving an exception.
1. Attacker can change the `auth_timestamp` field to match current time.
1. Attacker re-sends the request, now inside the CheckTimestamp grace period - receiving success, even though it should be rejected.

As the `auth_timestamp` isn't part of the signature payload, the signature is still valid, and the request will passes the CheckTimestamp guard. If the `auth_timestamp` *is* part of the signature payload, tampering with it in the request will cause the signatures to no longer match.

# 2. The original issue

The original issue is that the current time is used both when generating the initial signature, and when regenerating the signature for comparison within the Auth class. This means that if time passes between the request being sent and the request being verified, the two "current" times will not match, and therefore the signatures will not match.

By using the (now reliable) `auth_timestamp` field that is passed with the request when regenerating the signature, we no longer have two different "current" times, only the time that was used when originally signing the request.

The CheckTimestamp guard will still use `Carbon::now()`, as it should check the time of the request against the current time, but will not impact the signature generated for verification.

# 3. Bumping the version

I've bumped it to 3.0.4, to match what I'm guessing(?) will be the future tag. Changing the public `Request::payload` method parameters to include an additional parameter is technically a BC break, which would mean going to version 4.0.0. But as the previous fix altered the parameters without a major version bump, I've just gone with 3.0.4 instead.

I'd argue `Request::payload()` and `Request::signature()` shouldn't be part of the public API, and should actually be private or protected, at which point then I'd definitely recommend a 4.0.0 release.

Thanks for checking this out :smile: 