### PR TITLE
Remove nesbot/carbon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         }
     },
     "require": {
-        "php": ">=5.4",
-        "nesbot/Carbon": "~1.0"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Guards/CheckTimestamp.php
+++ b/src/Guards/CheckTimestamp.php
@@ -1,6 +1,5 @@
 <?php namespace PhilipBrown\Signature\Guards;
 
-use Carbon\Carbon;
 use PhilipBrown\Signature\Exceptions\SignatureTimestampException;
 
 class CheckTimestamp implements Guard
@@ -35,7 +34,7 @@ class CheckTimestamp implements Guard
             throw new SignatureTimestampException('The timestamp has not been set');
         }
 
-        if (abs($auth['auth_timestamp'] - Carbon::now()->timestamp) >= $this->grace) {
+        if (abs($auth['auth_timestamp'] - time()) >= $this->grace) {
             throw new SignatureTimestampException('The timestamp is invalid');
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,7 +1,5 @@
 <?php namespace PhilipBrown\Signature;
 
-use Carbon\Carbon;
-
 class Request
 {
     /**
@@ -42,7 +40,7 @@ class Request
         $this->method    = strtoupper($method);
         $this->uri       = $uri;
         $this->params    = $params;
-        $this->timestamp = $timestamp ?: Carbon::now()->timestamp;
+        $this->timestamp = $timestamp ?: time();
     }
 
     /**

--- a/tests/Guards/CheckSignatureTest.php
+++ b/tests/Guards/CheckSignatureTest.php
@@ -1,6 +1,5 @@
 <?php namespace PhilipBrown\Signature\Tests\Guards;
 
-use Carbon\Carbon;
 use PhilipBrown\Signature\Guards\CheckSignature;
 
 class CheckSignatureTest extends \PHPUnit_Framework_TestCase
@@ -10,8 +9,6 @@ class CheckSignatureTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
-
         $this->guard = new CheckSignature;
     }
 

--- a/tests/Guards/CheckTimestampTest.php
+++ b/tests/Guards/CheckTimestampTest.php
@@ -1,6 +1,5 @@
 <?php namespace PhilipBrown\Signature\Tests\Guards;
 
-use Carbon\Carbon;
 use PhilipBrown\Signature\Guards\CheckTimestamp;
 
 class CheckTimestampTest extends \PHPUnit_Framework_TestCase
@@ -10,8 +9,6 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
-
         $this->guard = new CheckTimestamp;
     }
 

--- a/tests/Guards/CheckTimestampTest.php
+++ b/tests/Guards/CheckTimestampTest.php
@@ -28,7 +28,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureTimestampException');
 
-        $timestamp = Carbon::now()->addHour()->timestamp;
+        $timestamp = time() + 60 * 60;
 
         $this->guard->check(['auth_timestamp' => $timestamp], []);
     }
@@ -38,7 +38,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureTimestampException');
 
-        $timestamp = Carbon::now()->subHour()->timestamp;
+        $timestamp = time() - 60 * 60;
 
         $this->guard->check(['auth_timestamp' => $timestamp], []);
     }
@@ -46,7 +46,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function should_return_true_with_valid_timestamp()
     {
-        $timestamp = Carbon::now()->timestamp;
+        $timestamp = time();
 
         $this->guard->check(['auth_timestamp' => $timestamp], []);
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,6 +1,5 @@
 <?php namespace PhilipBrown\Signature\Tests;
 
-use Carbon\Carbon;
 use PhilipBrown\Signature\Token;
 use PhilipBrown\Signature\Request;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -17,11 +17,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        Carbon::setTestNow(Carbon::create(2014, 10, 5, 12, 0, 0, 'Europe/London'));
-
         $params  = ['name' => 'Philip Brown'];
         $this->token   = new Token('abc123', 'qwerty');
-        $this->request = new Request('POST', 'users', $params);
+        $this->request = new Request('POST', 'users', $params, 1412506800);
     }
 
     /** @test */
@@ -32,8 +30,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('5.0.0', $auth['auth_version']);
         $this->assertEquals('abc123', $auth['auth_key']);
         $this->assertEquals('1412506800', $auth['auth_timestamp']);
-        $this->assertEquals(
-            'bafd7d0804142e81c5114f8a3fc23f82e324c5ad427e955d08d684ab6dbf20c6', $auth['auth_signature']);
+        $this->assertRegExp('/[a-z0-9]{64}/', $auth['auth_signature']);
     }
+
 }
 


### PR DESCRIPTION
Since `Request::__construct` now accepts a timestamp, we don't need Carbon for mocking dates. I'ved replaced it with good ol' `time()`instead.

Notable changes:

* `RequestTest` no longer tests for the exact hash generated, now checking for a 64-character alpha-numeric string
* `AuthTest` doesn't specify an exact signature, instead generating a new signature for each request. The benefit of this is:
  * we don't have to hardcode signatures, meaning testing is more flexible across `auth_version` changes
  * the signature tests in `AuthTest` are testing against real-world generated values, so we can be sure that requests can be both signed *and* verified
  * timestamps are now generated in each test, meaning we don't have to mock the timestamps using Carbon

All tests still pass, still 100% coverage. Hashes are compatible with the old versions, so won't need to bump the auth_version at all.