### PR TITLE
Allow custom HTTP request prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 5.1.0
+
+* Add the ability to use your own prefix for instead of `auth_*`. The default is still `auth_*` so no BC breaks are introduced.
+
 ## 5.0.0
 
 * `Request::payload()` and `Request::signature()` methods are now private. The `Request::sign()` method should be used instead.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,17 @@ catch (SignatureException $e) {
     // return 4xx
 }
 ```
+
+## Changing the default HTTP request prefix
+By default, this package uses `auth_*` in requests. You can change this behaviour when signing and and authenticating requests:
+```php
+// default, the HTTP request uses auth_version, auth_key, auth_timestamp and auth_signature
+$request->sign($token);
+// the HTTP request now uses x-version, x-key, x-timestamp and x-signature
+$request->sign($token, 'x-');
+```
+
+If you changed the default, you will need to authenticate the request accordingly:
+```php
+$auth->attempt($token, 'x-');
+```

--- a/src/Guards/CheckKey.php
+++ b/src/Guards/CheckKey.php
@@ -4,21 +4,24 @@ use PhilipBrown\Signature\Exceptions\SignatureKeyException;
 
 class CheckKey implements Guard
 {
+
     /**
      * Check to ensure the auth parameters
      * satisfy the rule of the guard
      *
-     * @param array $auth
-     * @param array $signature
+     * @param array  $auth
+     * @param array  $signature
+     * @param string $prefix
+     * @throws SignatureKeyException
      * @return bool
      */
-    public function check(array $auth, array $signature)
+    public function check(array $auth, array $signature, $prefix)
     {
-        if (! isset($auth['auth_key'])) {
+        if (! isset($auth[$prefix . 'key'])) {
             throw new SignatureKeyException('The authentication key has not been set');
         }
 
-        if ($auth['auth_key'] !== $signature['auth_key']) {
+        if ($auth[$prefix . 'key'] !== $signature[$prefix . 'key']) {
             throw new SignatureKeyException('The authentication key is not valid');
         }
 

--- a/src/Guards/CheckSignature.php
+++ b/src/Guards/CheckSignature.php
@@ -4,21 +4,24 @@ use PhilipBrown\Signature\Exceptions\SignatureSignatureException;
 
 class CheckSignature implements Guard
 {
+
     /**
      * Check to ensure the auth parameters
      * satisfy the rule of the guard
      *
-     * @param array $auth
-     * @param array $signature
+     * @param array  $auth
+     * @param array  $signature
+     * @param string $prefix
+     * @throws SignatureSignatureException
      * @return bool
      */
-    public function check(array $auth, array $signature)
+    public function check(array $auth, array $signature, $prefix)
     {
-        if (! isset($auth['auth_signature'])) {
+        if (! isset($auth[$prefix . 'signature'])) {
             throw new SignatureSignatureException('The signature has not been set');
         }
 
-        if ($auth['auth_signature'] !== $signature['auth_signature']) {
+        if ($auth[$prefix . 'signature'] !== $signature[$prefix . 'signature']) {
             throw new SignatureSignatureException('The signature is not valid');
         }
 

--- a/src/Guards/CheckTimestamp.php
+++ b/src/Guards/CheckTimestamp.php
@@ -25,17 +25,19 @@ class CheckTimestamp implements Guard
      * Check to ensure the auth parameters
      * satisfy the rule of the guard
      *
-     * @param array $auth
-     * @param array $signature
+     * @param array  $auth
+     * @param array  $signature
+     * @param string $prefix
+     * @throws SignatureTimestampException
      * @return bool
      */
-    public function check(array $auth, array $signature)
+    public function check(array $auth, array $signature, $prefix)
     {
-        if (! isset($auth['auth_timestamp'])) {
+        if (! isset($auth[$prefix . 'timestamp'])) {
             throw new SignatureTimestampException('The timestamp has not been set');
         }
 
-        if (abs($auth['auth_timestamp'] - Carbon::now()->timestamp) >= $this->grace) {
+        if (abs($auth[$prefix . 'timestamp'] - Carbon::now()->timestamp) >= $this->grace) {
             throw new SignatureTimestampException('The timestamp is invalid');
         }
 

--- a/src/Guards/CheckVersion.php
+++ b/src/Guards/CheckVersion.php
@@ -5,21 +5,24 @@ use PhilipBrown\Signature\Exceptions\SignatureVersionException;
 
 class CheckVersion implements Guard
 {
+
     /**
      * Check to ensure the auth parameters
      * satisfy the rule of the guard
      *
-     * @param array $auth
-     * @param array $signature
+     * @param array  $auth
+     * @param array  $signature
+     * @param string $prefix
+     * @throws SignatureVersionException
      * @return bool
      */
-    public function check(array $auth, array $signature)
+    public function check(array $auth, array $signature, $prefix)
     {
-        if (! isset($auth['auth_version'])) {
+        if (! isset($auth[$prefix . 'version'])) {
             throw new SignatureVersionException('The version has not been set');
         }
 
-        if ($auth['auth_version'] !== $signature['auth_version']) {
+        if ($auth[$prefix . 'version'] !== $signature[$prefix . 'version']) {
             throw new SignatureVersionException('The signature version is not correct');
         }
 

--- a/src/Guards/Guard.php
+++ b/src/Guards/Guard.php
@@ -4,13 +4,15 @@ use PhilipBrown\Signature\Signature;
 
 interface Guard
 {
+
     /**
      * Check to ensure the auth parameters
      * satisfy the rule of the guard
      *
-     * @param array $auth
-     * @param array $signature
+     * @param array  $auth
+     * @param array  $signature
+     * @param string $prefix
      * @return bool
      */
-    public function check(array $auth, array $signature);
+    public function check(array $auth, array $signature, $prefix);
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,10 +4,8 @@ use Carbon\Carbon;
 
 class Request
 {
-    /**
-     * @var string
-     */
-    private $version = '5.0.0';
+
+    const VERSION = '5.1.0';
 
     /**
      * @var string
@@ -57,7 +55,7 @@ class Request
     public function sign(Token $token, $prefix = self::PREFIX)
     {
         $auth = [
-            $prefix . 'version'   => $this->version,
+            $prefix . 'version'   => self::VERSION,
             $prefix . 'key'       => $token->key(),
             $prefix . 'timestamp' => $this->timestamp,
         ];

--- a/src/Request.php
+++ b/src/Request.php
@@ -29,6 +29,8 @@ class Request
      */
     private $timestamp;
 
+    const PREFIX = 'auth_';
+
     /**
      * Create a new Request
      *
@@ -48,22 +50,23 @@ class Request
     /**
      * Sign the Request with a Token
      *
-     * @param Token $token
+     * @param Token  $token
+     * @param string $prefix
      * @return array
      */
-    public function sign(Token $token)
+    public function sign(Token $token, $prefix = self::PREFIX)
     {
         $auth = [
-            'auth_version'   => $this->version,
-            'auth_key'       => $token->key(),
-            'auth_timestamp' => $this->timestamp,
+            $prefix . 'version'   => $this->version,
+            $prefix . 'key'       => $token->key(),
+            $prefix . 'timestamp' => $this->timestamp,
         ];
 
         $payload = $this->payload($auth, $this->params);
 
         $signature = $this->signature($payload, $this->method, $this->uri, $token->secret());
 
-        $auth['auth_signature'] = $signature;
+        $auth[$prefix . 'signature'] = $signature;
 
         return $auth;
     }

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -13,10 +13,10 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->params = [
-            'auth_version'   => '5.0.0',
+            'auth_version'   => '5.1.0',
             'auth_key'       => 'abc123',
             'auth_timestamp' => '1412506800',
-            'auth_signature' => 'bafd7d0804142e81c5114f8a3fc23f82e324c5ad427e955d08d684ab6dbf20c6',
+            'auth_signature' => '1144e9c47773e38d4436cf48bf32a9968a3f41c829e1a70129d690461b4abb0f',
             'name'           => 'Philip Brown'
         ];
 
@@ -84,7 +84,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function should_return_true_on_successfull_authentication()
+    public function should_return_true_on_successful_authentication()
     {
         $auth = new Auth('POST', 'users', $this->params, [
             new CheckKey,

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -17,7 +17,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
             'auth_key'       => 'abc123',
             'auth_timestamp' => '1412506800',
             'auth_signature' => 'bafd7d0804142e81c5114f8a3fc23f82e324c5ad427e955d08d684ab6dbf20c6',
-            'name' => 'Philip Brown'
+            'name'           => 'Philip Brown'
         ];
 
         $this->token = new Token('abc123', 'qwerty');

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -95,4 +95,27 @@ class AuthTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($auth->attempt($this->token));
     }
+
+    /** @test */
+    public function should_return_true_on_successful_attempt_with_custom_prefix()
+    {
+        $params = [
+            'x-version'   => '5.1.0',
+            'x-key'       => 'abc123',
+            'x-timestamp' => '1412506800',
+            'x-signature' => 'efb40418fdab26f11fead90f3d0e469ae5a21f3dd915613f6a76798124811f7b',
+            'name'        => 'Philip Brown'
+        ];
+
+        $token = new Token('abc123', 'qwerty');
+
+        $auth = new Auth('POST', 'users', $params, [
+            new CheckKey,
+            new CheckVersion,
+            new CheckTimestamp,
+            new CheckSignature
+        ]);
+
+        $this->assertTrue($auth->attempt($token, 'x-'));
+    }
 }

--- a/tests/Guards/CheckKeyTest.php
+++ b/tests/Guards/CheckKeyTest.php
@@ -17,7 +17,7 @@ class CheckKeyTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureKeyException');
 
-        $this->guard->check([], ['auth_key' => 'abc123']);
+        $this->guard->check([], ['auth_key' => 'abc123'], 'auth_');
     }
 
     /** @test */
@@ -25,14 +25,14 @@ class CheckKeyTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureKeyException');
 
-        $this->guard->check(['auth_key' => 'edf456'], ['auth_key' => 'abc123']);
+        $this->guard->check(['auth_key' => 'edf456'], ['auth_key' => 'abc123'], 'auth_');
     }
 
     /** @test */
     public function should_return_true_with_valid_key()
     {
         $this->assertTrue($this->guard->check(
-            ['auth_key' => 'abc123'], ['auth_key' => 'abc123'])
-        );
+            ['auth_key' => 'abc123'], ['auth_key' => 'abc123'], 'auth_'
+        ));
     }
 }

--- a/tests/Guards/CheckSignatureTest.php
+++ b/tests/Guards/CheckSignatureTest.php
@@ -20,7 +20,7 @@ class CheckSignatureTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureSignatureException');
 
-        $this->guard->check([], []);
+        $this->guard->check([], [], 'auth_');
     }
 
     /** @test */
@@ -28,7 +28,7 @@ class CheckSignatureTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureException');
 
-        $this->guard->check(['auth_signature' => 'hello'], ['auth_signature' => 'world']);
+        $this->guard->check(['auth_signature' => 'hello'], ['auth_signature' => 'world'], 'auth_');
     }
 
     /** @test */
@@ -36,6 +36,6 @@ class CheckSignatureTest extends \PHPUnit_Framework_TestCase
     {
         $hash = '74386c24552f7a044bba201b46bd713d40050b9c411d8e7d0aeb98e7e3ed6e83';
 
-        $this->assertTrue($this->guard->check(['auth_signature' => $hash], ['auth_signature' => $hash]));
+        $this->assertTrue($this->guard->check(['auth_signature' => $hash], ['auth_signature' => $hash], 'auth_'));
     }
 }

--- a/tests/Guards/CheckTimestampTest.php
+++ b/tests/Guards/CheckTimestampTest.php
@@ -20,7 +20,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureTimestampException');
 
-        $this->guard->check([], []);
+        $this->guard->check([], [], 'auth_');
     }
 
     /** @test */
@@ -30,7 +30,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
 
         $timestamp = Carbon::now()->addHour()->timestamp;
 
-        $this->guard->check(['auth_timestamp' => $timestamp], []);
+        $this->guard->check(['auth_timestamp' => $timestamp], [], 'auth_');
     }
 
     /** @test */
@@ -40,7 +40,7 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
 
         $timestamp = Carbon::now()->subHour()->timestamp;
 
-        $this->guard->check(['auth_timestamp' => $timestamp], []);
+        $this->guard->check(['auth_timestamp' => $timestamp], [], 'auth_');
     }
 
     /** @test */
@@ -48,6 +48,6 @@ class CheckTimestampTest extends \PHPUnit_Framework_TestCase
     {
         $timestamp = Carbon::now()->timestamp;
 
-        $this->guard->check(['auth_timestamp' => $timestamp], []);
+        $this->guard->check(['auth_timestamp' => $timestamp], [], 'auth_');
     }
 }

--- a/tests/Guards/CheckVersionTest.php
+++ b/tests/Guards/CheckVersionTest.php
@@ -17,7 +17,7 @@ class CheckVersionTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureVersionException');
 
-        $this->guard->check([], ['auth_version' => '4.0.0']);
+        $this->guard->check([], ['auth_version' => '4.0.0'], 'auth_');
     }
 
     /** @test */
@@ -25,12 +25,12 @@ class CheckVersionTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('PhilipBrown\Signature\Exceptions\SignatureVersionException');
 
-        $this->guard->check(['auth_version' => '1.1'], ['auth_version' => '4.0.0']);
+        $this->guard->check(['auth_version' => '1.1'], ['auth_version' => '4.0.0'], 'auth_');
     }
 
     /** @test */
     public function should_return_true_with_valid_version_number()
     {
-        $this->assertTrue($this->guard->check(['auth_version' => '4.0.0'], ['auth_version' => '4.0.0']));
+        $this->assertTrue($this->guard->check(['auth_version' => '4.0.0'], ['auth_version' => '4.0.0'], 'auth_'));
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -6,9 +6,6 @@ use PhilipBrown\Signature\Request;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var array */
-    private $auth;
-
     /** @var Token */
     private $token;
 
@@ -35,5 +32,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'bafd7d0804142e81c5114f8a3fc23f82e324c5ad427e955d08d684ab6dbf20c6', $auth['auth_signature']);
     }
-}
 
+    /** @test */
+    public function should_accept_custom_prefix()
+    {
+        $auth = $this->request->sign($this->token, 'x-');
+
+        $this->assertEquals('5.0.0', $auth['x-version']);
+        $this->assertEquals('abc123', $auth['x-key']);
+        $this->assertEquals('1412506800', $auth['x-timestamp']);
+        $this->assertEquals(
+            '4fed31bd83f9ddec343a19d4bde4d0db168715a8c3e663ebda253a12e4e75e6f', $auth['x-signature']);
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -26,11 +26,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $auth = $this->request->sign($this->token);
 
-        $this->assertEquals('5.0.0', $auth['auth_version']);
+        $this->assertEquals('5.1.0', $auth['auth_version']);
         $this->assertEquals('abc123', $auth['auth_key']);
         $this->assertEquals('1412506800', $auth['auth_timestamp']);
         $this->assertEquals(
-            'bafd7d0804142e81c5114f8a3fc23f82e324c5ad427e955d08d684ab6dbf20c6', $auth['auth_signature']);
+            '1144e9c47773e38d4436cf48bf32a9968a3f41c829e1a70129d690461b4abb0f', $auth['auth_signature']);
     }
 
     /** @test */
@@ -38,10 +38,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $auth = $this->request->sign($this->token, 'x-');
 
-        $this->assertEquals('5.0.0', $auth['x-version']);
+        $this->assertEquals('5.1.0', $auth['x-version']);
         $this->assertEquals('abc123', $auth['x-key']);
         $this->assertEquals('1412506800', $auth['x-timestamp']);
         $this->assertEquals(
-            '4fed31bd83f9ddec343a19d4bde4d0db168715a8c3e663ebda253a12e4e75e6f', $auth['x-signature']);
+            'efb40418fdab26f11fead90f3d0e469ae5a21f3dd915613f6a76798124811f7b', $auth['x-signature']);
     }
 }


### PR DESCRIPTION
This pull request allows to overwrite the default "auth_" prefix in http requests. This can be useful to avoid conflicts, work with existing APIs or simply to suit the users preference.

The default prefix is still "auth_", so I've bumped the version to 5.1.0 as no BC breaks are introduced.

I've also added a quick example in README.MD.