### PR TITLE
add empty default for Request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
 ## 5.1.2
+
 * Set the value of `array_change_key_case`
+* Set default value for request params to empty array
 
 ## 5.1.0
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -35,7 +35,7 @@ class Request
      * @param array $params
      * @param integer $timestamp
      */
-    public function __construct($method, $uri, array $params, $timestamp = null)
+    public function __construct($method, $uri, array $params = [], $timestamp = null)
     {
         $this->method    = strtoupper($method);
         $this->uri       = $uri;


### PR DESCRIPTION
Tiny change, but essentially I came across a use case where I just wanted to sign a basic GET request, with no other params really.

This change will allow me to write `$request = new Request('GET', '/api/getData')` instead of `$request = New Request('GET', '/api/getData', [])`.

I didn't bump the version as it shouldn't affect anything really.

Cheers