### PR TITLE
allow changing the VERSION constant

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -2,6 +2,8 @@
 
 class Auth
 {
+    protected $request = Request::class;
+
     /**
      * @var string
      */
@@ -56,7 +58,8 @@ class Auth
         $auth = $this->getAuthParams($prefix);
         $body = $this->getBodyParams($prefix);
 
-        $request   = new Request($this->method, $this->uri, $body, $auth[$prefix . 'timestamp']);
+        $request_class = $this->request;
+        $request   = new $request_class($this->method, $this->uri, $body, $auth[$prefix . 'timestamp']);
         $signature = $request->sign($token, $prefix);
 
         foreach ($this->guards as $guard) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -52,7 +52,7 @@ class Request
     public function sign(Token $token, $prefix = self::PREFIX)
     {
         $auth = [
-            $prefix . 'version'   => self::VERSION,
+            $prefix . 'version'   => static::VERSION,
             $prefix . 'key'       => $token->key(),
             $prefix . 'timestamp' => $this->timestamp,
         ];

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -7,6 +7,8 @@ use PhilipBrown\Signature\Guards\CheckKey;
 use PhilipBrown\Signature\Guards\CheckVersion;
 use PhilipBrown\Signature\Guards\CheckSignature;
 use PhilipBrown\Signature\Guards\CheckTimestamp;
+use PhilipBrown\Signature\Tests\Mocks\CustomRequest;
+use PhilipBrown\Signature\Tests\Mocks\CustomAuth;
 
 class AuthTest extends \PHPUnit_Framework_TestCase
 {
@@ -109,5 +111,24 @@ class AuthTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->assertTrue($auth->attempt($token, 'x-'));
+    }
+
+    /** @test */
+    public function should_return_true_on_successful_authentication_using_custom_auth()
+    {
+        $params  = ['name' => 'Philip Brown'];
+        $token   = new Token('abc123', 'qwerty');
+        $request = new CustomRequest('POST', 'users', $params);
+        $signed  = $request->sign($token);
+        $params  = array_merge($params, $signed);
+
+        $auth = new CustomAuth('POST', 'users', $params, [
+            new CheckKey,
+            new CheckVersion,
+            new CheckTimestamp,
+            new CheckSignature
+        ]);
+
+        $this->assertTrue($auth->attempt($token));
     }
 }

--- a/tests/Mocks/CustomAuth.php
+++ b/tests/Mocks/CustomAuth.php
@@ -1,0 +1,8 @@
+<?php namespace PhilipBrown\Signature\Tests\Mocks;
+
+use PhilipBrown\Signature\Auth;
+
+class CustomAuth extends Auth
+{
+    protected $request = CustomRequest::class;
+}

--- a/tests/Mocks/CustomRequest.php
+++ b/tests/Mocks/CustomRequest.php
@@ -1,0 +1,8 @@
+<?php namespace PhilipBrown\Signature\Tests\Mocks;
+
+use PhilipBrown\Signature\Request;
+
+class CustomRequest extends Request
+{
+    const VERSION = '0.0.1';
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,6 +2,7 @@
 
 use PhilipBrown\Signature\Token;
 use PhilipBrown\Signature\Request;
+use PhilipBrown\Signature\Tests\Mocks\CustomRequest;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
@@ -16,6 +17,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $params  = ['name' => 'Philip Brown'];
         $this->token   = new Token('abc123', 'qwerty');
         $this->request = new Request('POST', 'users', $params, 1412506800);
+        $this->custom_request = new CustomRequest('POST', 'users', $params, 1412506800);
     }
 
     /** @test */
@@ -38,5 +40,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('abc123', $auth['x-key']);
         $this->assertEquals('1412506800', $auth['x-timestamp']);
         $this->assertRegExp('/[a-z0-9]{64}/', $auth['x-signature']);
+    }
+
+    /** @test */
+    public function should_sign_custom_request()
+    {
+        $auth = $this->custom_request->sign($this->token);
+
+        $this->assertEquals('0.0.1', $auth['auth_version']);
+        $this->assertEquals('abc123', $auth['auth_key']);
+        $this->assertEquals('1412506800', $auth['auth_timestamp']);
+        $this->assertRegExp('/[a-z0-9]{64}/', $auth['auth_signature']);
     }
 }


### PR DESCRIPTION
This pull request allows to overwrite the default version in http requests by subclassing. This can be useful to when the developer using this composer package want to control the version number.