### PR TITLE
Mitigate timing attack vulnerability

### DIFF
--- a/src/Guards/CheckSignature.php
+++ b/src/Guards/CheckSignature.php
@@ -21,7 +21,7 @@ class CheckSignature implements Guard
             throw new SignatureSignatureException('The signature has not been set');
         }
 
-        if ($auth[$prefix . 'signature'] !== $signature[$prefix . 'signature']) {
+        if (hash_equals($auth[$prefix . 'signature'], $signature[$prefix . 'signature'])) {
             throw new SignatureSignatureException('The signature is not valid');
         }
 


### PR DESCRIPTION
This small fix uses a constant-time function to mitigate timing attacks on the signature.
I'm here using PHP's hash_equals() function to achieve that. This requires PHP >= 5.6, but polyfills for earlier versions are available.