### PR TITLE
Fixed the CheckSignature condition

### DIFF
--- a/src/Guards/CheckSignature.php
+++ b/src/Guards/CheckSignature.php
@@ -21,7 +21,7 @@ class CheckSignature implements Guard
             throw new SignatureSignatureException('The signature has not been set');
         }
 
-        if (hash_equals($auth[$prefix . 'signature'], $signature[$prefix . 'signature'])) {
+        if (!hash_equals($auth[$prefix . 'signature'], $signature[$prefix . 'signature'])) {
             throw new SignatureSignatureException('The signature is not valid');
         }
 


### PR DESCRIPTION
The update is pretty self-explanatory. If the hashes are NOT equal, i.e. if the hash_equals function returns false, we'd want to throw the exception.

This was a regression introduced in #27 , a previous PR of mine. My apologies.